### PR TITLE
Fix MPI process validation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -19,7 +19,10 @@ int main(int argc, char** argv) {
     MPI_Comm_size(MPI_COMM_WORLD, &nProcs);
 
     int sqrt_p = static_cast<int>(std::sqrt(nProcs));
-    if (iProc == 0 && sqrt_p * sqrt_p != nProcs) {
+    if (sqrt_p * sqrt_p != nProcs) {
+        if (iProc == 0) {
+            std::cerr << "Number of processes must be a perfect square" << std::endl;
+        }
         MPI_Finalize();
         return 1;
     }


### PR DESCRIPTION
## Summary
- exit all ranks if the number of MPI processes isn't a perfect square

## Testing
- `g++ -std=c++17 main.cpp -o main -lmpi -larmadillo` *(fails: mpi.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f433b5a0c832cb5975a81a41c4cee